### PR TITLE
Fixes #15 Remove Unused Protobuf Imports

### DIFF
--- a/src/main/proto/BasicTypes.proto
+++ b/src/main/proto/BasicTypes.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package proto;
 
 import "Timestamp.proto";
-import "Duration.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;

--- a/src/main/proto/Freeze.proto
+++ b/src/main/proto/Freeze.proto
@@ -5,9 +5,6 @@ package proto;
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
-import "Duration.proto";
-import "Timestamp.proto";
-
 /* Set the freezing period in which the platform will stop creating events and accepting transactions. This is used before safely shut down the platform for maintenance. */
 message FreezeTransactionBody {
     int32 startHour = 1; // The start hour (in UTC time), a value between 0 and 23

--- a/src/main/proto/ResponseHeader.proto
+++ b/src/main/proto/ResponseHeader.proto
@@ -5,7 +5,6 @@ package proto;
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
-import "TransactionResponse.proto";
 import "QueryHeader.proto";
 import "ResponseCode.proto";
 

--- a/src/main/proto/Transaction.proto
+++ b/src/main/proto/Transaction.proto
@@ -6,7 +6,6 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 
-import "Duration.proto";
 import "BasicTypes.proto";
 import "TransactionBody.proto";
 


### PR DESCRIPTION
Removed unecessary protobuf imports that
which were causing compile time warnings
when building downstream client libraries.