### PR TITLE
Remove log4j as it is not used and causing errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
 
     <properties>
         <app.name>hedera-protobuf-java-api</app.name>
-        <log4j-version>2.8.2</log4j-version>
         <grpc.version>1.13.1</grpc.version>
         <os.plugin.version>1.6.0</os.plugin.version>
         <protobuf.plugin.version>0.5.0</protobuf.plugin.version>
@@ -102,19 +101,6 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.11</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>${log4j-version}</version>
-            <type>pom</type>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <version>2.8.2</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
This is causing errors in the Java SDK when imported into an Android project because `log4j-core` contains annotation processors but is placed on the compile classpath. This is the only place it appears in the SDK's dependency tree that I can find.

`mvn compile` passes locally.