### PR TITLE
Exclude protobuf-java version 3.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.5.1</version>
+            <version>(,3.10.0),(3.10.0,)</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
That release broke compatibility with Android, 3.9.2 is safe and a fix is due in 3.11: https://github.com/protocolbuffers/protobuf/issues/6718#issuecomment-546058263