### PR TITLE
Final version of HCS protobuf, and include other non-HCS response cod…

### DIFF
--- a/src/main/proto/BasicTypes.proto
+++ b/src/main/proto/BasicTypes.proto
@@ -68,7 +68,7 @@ message TopicID {
  */
 message Key {
     oneof key {
-        ContractID contractID = 1; // smart contract instance that is authorized as if it had signed with a key
+        ContractID contractID = 1 [deprecated = true]; // smart contract instance that is authorized as if it had signed with a key
         bytes ed25519 = 2; // ed25519 public key bytes
         bytes RSA_3072 = 3; //RSA-3072 public key bytes
         bytes ECDSA_384 = 4; //ECDSA with the p-384 curve public key bytes
@@ -95,7 +95,7 @@ message KeyList {
 message Signature {
     option deprecated = true;
     oneof signature {
-        bytes contract = 1; // smart contract virtual signature (always length zero)
+        bytes contract = 1 [deprecated = true]; // smart contract virtual signature (always length zero)
         bytes ed25519 = 2; // ed25519 signature bytes
         bytes RSA_3072 = 3; //RSA-3072 signature bytes
         bytes ECDSA_384 = 4; //ECDSA p-384 signature bytes
@@ -179,9 +179,6 @@ enum HederaFunctionality {
     ContractAutoRenew = 34; // Contract Auto Renew
     getVersion = 35; //Get Version
     TransactionGetReceipt = 36; // Transaction Get Receipt
-
-    // New functionality in the HCS release below here
-
     ConsensusCreateTopic = 50;
     ConsensusUpdateTopic = 51;
     ConsensusDeleteTopic = 52;
@@ -242,4 +239,14 @@ message NodeAddress {
 /* Gives the node addresses in the address book */
 message NodeAddressBook {
     repeated NodeAddress nodeAddress = 1; // Contains multiple Node Address for the network
+}
+
+message Setting {
+    string name = 1;  // name of the property
+    string value = 2; // value of the property
+    bytes data = 3; // any data associated with property
+}
+
+message ServicesConfigurationList{
+    repeated Setting nameValue = 1; // list of name value pairs of the application properties
 }

--- a/src/main/proto/ResponseCode.proto
+++ b/src/main/proto/ResponseCode.proto
@@ -135,9 +135,11 @@ enum ResponseCodeEnum {
   FEE_SCHEDULE_FILE_PART_UPLOADED = 104; // Fee Schedule Proto File Part uploaded
   EXCHANGE_RATE_CHANGE_LIMIT_EXCEEDED = 105; // The change on Exchange Rate exceeds Exchange_Rate_Allowed_Percentage
   MAX_CONTRACT_STORAGE_EXCEEDED = 106;  // Contract permanent storage exceeded the currently allowable limit
-  TRANSAFER_ACCOUNT_SAME_AS_DELETE_ACCOUNT = 107; // Transfer Account should not be same as Account to be deleted
+  TRANSFER_ACCOUNT_SAME_AS_DELETE_ACCOUNT = 107; // Transfer Account should not be same as Account to be deleted
   TOTAL_LEDGER_BALANCE_INVALID = 108;
   EXPIRATION_REDUCTION_NOT_ALLOWED = 110; // The expiration date/time on a smart contract may not be reduced
+  MAX_GAS_LIMIT_EXCEEDED = 111; //Gas exceeded currently allowable gas limit per transaction
+  MAX_FILE_SIZE_EXCEEDED = 112;  // File size exceeded the currently allowable limit
 
   // New functionality in the HCS release below here
 
@@ -159,8 +161,7 @@ enum ResponseCodeEnum {
   // An admin key was not specified on the topic, so there must not be an autorenew account.
   AUTORENEW_ACCOUNT_NOT_ALLOWED = 160;
 
-  // The autoRenewAccount didn't sign the transaction.
-  AUTORENEW_ACCOUNT_SIGNATURE_MISSING = 161;
+  AUTORENEW_ACCOUNT_SIGNATURE_MISSING = 161 [deprecated = true];
 
   // The topic has expired, was not automatically renewed, and is in a 7 day grace period before the topic will be
   // deleted unrecoverably. This error response code will not be returned until autoRenew functionality is supported

--- a/src/main/proto/SystemDelete.proto
+++ b/src/main/proto/SystemDelete.proto
@@ -13,7 +13,6 @@ message SystemDeleteTransactionBody {
     oneof id {
         FileID fileID = 1; // The file ID of the file to delete, in the format used in transactions
         ContractID contractID = 2; // The contract ID instance to delete, in the format used in transactions
-        TopicID topicID = 4;
     }
     TimestampSeconds expirationTime = 3; // The timestamp in seconds at which the "deleted" file should truly be permanently deleted
 }

--- a/src/main/proto/SystemUndelete.proto
+++ b/src/main/proto/SystemUndelete.proto
@@ -12,6 +12,5 @@ message SystemUndeleteTransactionBody {
     oneof id {
         FileID fileID = 1; // The file ID to undelete, in the format used in transactions
         ContractID contractID = 2; // The contract ID instance to undelete, in the format used in transactions
-        TopicID topicID = 3;
     }
 }


### PR DESCRIPTION
- Remove TopicID from SystemDelete/SystemUndelete. This functionality will be added in services release 0.5, not 0.4.
- Deprecate new response code AUTORENEW_ACCOUNT_SIGNATURE_MISSING. This will be removed when 0.4 is release to testnet. INVALID_SIGNATURE will be used consistently for cases of missing required signatures on an entity (distinct from the transaction payer's signature).
- Update a few response codes on the HCS branch unrelated to HCS that are still being added in 0.4 (MAX_GAS_LIMIT_EXCEEDED, MAX_FILE_SIZE_EXCEEDED, TRANSFER_ACCOUNT_SAME_AS_DELETE_ACCOUNT spelling fixed)
- Added BasicTypes Settings type which is also in 0.4 (non-HCS).